### PR TITLE
Supplied attributes overrides can override default sequences

### DIFF
--- a/src/Woodling/Factory/Runner.php
+++ b/src/Woodling/Factory/Runner.php
@@ -71,10 +71,12 @@ class Runner
             unset($attributes[':sequences']);
         }
 
-        $attributes = $attributes + $blueprint->getAttributes();
         $sequences = $sequences + $blueprint->getSequences();
-        $this->withAttributes($instance, $attributes);
         $this->withSequences($instance, $sequences);
+
+        $attributes = $attributes + $blueprint->getAttributes();
+        $this->withAttributes($instance, $attributes);
+
         return $instance;
     }
 

--- a/tests/Woodling/Factory/Runner.test.php
+++ b/tests/Woodling/Factory/Runner.test.php
@@ -129,6 +129,21 @@ class TestWoodlingFactoryRunner extends PHPUnit_Framework_TestCase
         $this->assertEquals(1, $instance->index);
     }
 
+    public function testMakeWithSequenceOverrideWithAttribute()
+    {
+        $className = 'stdClass';
+        $sequences = array(
+            'email' => function($i) { return "username{$i}@hostname.com"; },
+        );
+        $attributeOverrides = array(
+            'email' => 'name@hostname.com'
+        );
+        $blueprint = new Blueprint();
+        $blueprint->setSequences($sequences);
+        $instance = $this->runner->make($className, $blueprint, $attributeOverrides);
+        $this->assertEquals('name@hostname.com', $instance->email);
+    }
+
     public function testMakeWithVariousAttributes()
     {
         $className = 'stdClass';


### PR DESCRIPTION
This re-ordering allows supplied attributes to override a default sequence.  All of the other tests work just as before.
