### PR TITLE
PHP 5.3 compatibility: no `callable` type hint

### DIFF
--- a/src/Woodling/Blueprint.php
+++ b/src/Woodling/Blueprint.php
@@ -79,7 +79,7 @@ class Blueprint
      * @param string $key
      * @param callable $closure
      */
-    public function setSequence($key, callable $closure)
+    public function setSequence($key, $closure)
     {
         $this->sequences[$key] = $closure;
     }


### PR DESCRIPTION
This seems to be the only change I needed to make to get Woodling to work on PHP 5.3.
