### PR TITLE
Throw error on failed save

### DIFF
--- a/src/Woodling/Core.php
+++ b/src/Woodling/Core.php
@@ -93,8 +93,13 @@ class Core
     public function saved($className, $attributeOverrides = array())
     {
         $instance = $this->retrieve($className, $attributeOverrides);
-        $instance->{$this->persistMethod}();
-        return $instance;
+        $success = $instance->{$this->persistMethod}();
+        if ($success)
+        {
+            return $instance;
+        } else {
+            throw new \Exception("Failed to save model");
+        }
     }
 
     /**
@@ -136,5 +141,4 @@ class Core
 
         return $list;
     }
-
 }

--- a/tests/Woodling/Core.test.php
+++ b/tests/Woodling/Core.test.php
@@ -126,7 +126,8 @@ class TestWoodlingCore extends PHPUnit_Framework_TestCase
         $modelName = 'stdClass';
         $modelMock = $this->getMock($modelName, array($persistMethodName));
         $modelMock->expects($this->once())
-            ->method($persistMethodName);
+            ->method($persistMethodName)
+            ->will($this->returnValue($modelMock));
         $coreMock = $this->getMock('Woodling\Core', array('retrieve'));
         $coreMock->expects($this->once())
             ->method('retrieve')
@@ -136,13 +137,35 @@ class TestWoodlingCore extends PHPUnit_Framework_TestCase
         $coreMock->saved($modelName);
     }
 
+    /**
+     * @expectedException              Exception
+     * @expectedExceptionMessageRegExp Failed to save model 
+     */
+    public function testFailedSave()
+    {
+        $persistMethodName = 'save';
+        $modelName = 'stdClass';
+        $modelMock = $this->getMock($modelName, array($persistMethodName));
+        $modelMock->expects($this->once())
+            ->method($persistMethodName)
+            ->will($this->returnValue(false));
+        $coreMock = $this->getMock('Woodling\Core', array('retrieve'));
+        $coreMock->expects($this->once())
+            ->method('retrieve')
+            ->with($this->equalTo($modelName))
+            ->will($this->returnValue($modelMock));
+        $coreMock->persistMethod = $persistMethodName;
+        $coreMock->saved($modelName); 
+    }
+
     public function testSavedWithOverrides()
     {
         $overrides = array('name' => 'John Doe');
         $modelName = 'stdClass';
         $modelMock = $this->getMock($modelName, array('save'));
         $modelMock->expects($this->once())
-            ->method('save');
+            ->method('save')
+            ->will($this->returnValue($modelMock));
         $coreMock = $this->getMock('Woodling\Core', array('retrieve'));
         $coreMock->expects($this->once())
             ->method('retrieve')


### PR DESCRIPTION
Solves issue #8 

Added check, if model saved method returns false. If so, throw error.

Added test to check that behaviour.

In `testSaved` and `testSavedWithOverrides` force mock to return something else than `false`.
